### PR TITLE
Refactor job queue UI and add reactive updates

### DIFF
--- a/src/core/Fip.Strive.Core.Ingestion/Registration.cs
+++ b/src/core/Fip.Strive.Core.Ingestion/Registration.cs
@@ -13,17 +13,17 @@ public static class Registration
             scan.FromAssembliesOf(typeof(IFileClassifier))
                 .AddClasses(classes => classes.AssignableTo<IFileClassifier>())
                 .AsImplementedInterfaces()
-                .WithSingletonLifetime()
+                .WithScopedLifetime()
         );
 
         services.Scan(scan =>
             scan.FromAssembliesOf(typeof(IFileExtractor))
                 .AddClasses(classes => classes.AssignableTo<IFileExtractor>())
                 .AsImplementedInterfaces()
-                .WithSingletonLifetime()
+                .WithScopedLifetime()
         );
 
-        services.AddSingleton<IClassifier, Classifier>();
-        services.AddSingleton<IExtractor, Extractor>();
+        services.AddScoped<IClassifier, Classifier>();
+        services.AddScoped<IExtractor, Extractor>();
     }
 }

--- a/src/harvest/Fip.Strive.Harvester.Application/Core/Queue/Components/QueueRunner.cs
+++ b/src/harvest/Fip.Strive.Harvester.Application/Core/Queue/Components/QueueRunner.cs
@@ -43,6 +43,7 @@ public class QueueRunner(
         {
             try
             {
+                metrics.IncrementActiveWorkers();
                 await RunJobAsync(ct, job);
             }
             catch (OperationCanceledException)
@@ -58,6 +59,7 @@ public class QueueRunner(
             }
             finally
             {
+                metrics.RecordCompletion();
                 metrics.DecrementActiveWorkers();
             }
         }
@@ -67,13 +69,11 @@ public class QueueRunner(
 
     private async Task RunJobAsync(CancellationToken ct, JobDetails job)
     {
-        metrics.IncrementActiveWorkers();
         await queue.MarkAsStartedAsync(job.Id, ct);
 
         await ExecuteWorkerAsync(job, ct);
 
         await queue.MarkAsSuccessAsync(job.Id, ct);
-        metrics.RecordCompletion();
     }
 
     private async Task ExecuteWorkerAsync(JobDetails job, CancellationToken ct)

--- a/src/harvest/Fip.Strive.Harvester.Application/Core/Queue/Repositories/Contracts/IJobReader.cs
+++ b/src/harvest/Fip.Strive.Harvester.Application/Core/Queue/Repositories/Contracts/IJobReader.cs
@@ -1,17 +1,18 @@
 using Fip.Strive.Core.Domain.Schemas.Queue.Enums;
 using Fip.Strive.Core.Domain.Schemas.Queue.Models;
-using Fip.Strive.Harvester.Application.Core.Queue.Models;
 using Fip.Strive.Harvester.Application.Infrastructure.Models;
 
 namespace Fip.Strive.Harvester.Application.Core.Queue.Repositories.Contracts;
 
 public interface IJobReader
 {
-    public PagedResponse<JobDetails> GetUpcommingJobs(int page, int size);
+    PagedResponse<JobDetails> GetUpcommingJobs(int page, int size);
 
-    public PagedResponse<JobDetails> GetSucceededJobs(int page, int size);
+    PagedResponse<JobDetails> GetSucceededJobs(int page, int size);
 
-    public PagedResponse<JobDetails> GetFailedJobs(int page, int size);
+    PagedResponse<JobDetails> GetFailedJobs(int page, int size);
 
-    public PagedResponse<JobDetails> GetJobs(JobStatus status, int page, int size);
+    PagedResponse<JobDetails> GetJobs(JobStatus status, int page, int size);
+
+    PagedResponse<JobDetails> GetJobs(int page, int size, params JobStatus[] statuses);
 }

--- a/src/harvest/Fip.Strive.Harvester.Application/Core/Queue/Repositories/LiteDbJobReader.cs
+++ b/src/harvest/Fip.Strive.Harvester.Application/Core/Queue/Repositories/LiteDbJobReader.cs
@@ -1,6 +1,5 @@
 using Fip.Strive.Core.Domain.Schemas.Queue.Enums;
 using Fip.Strive.Core.Domain.Schemas.Queue.Models;
-using Fip.Strive.Harvester.Application.Core.Queue.Models;
 using Fip.Strive.Harvester.Application.Core.Queue.Repositories.Contracts;
 using Fip.Strive.Harvester.Application.Infrastructure.Contexts;
 using Fip.Strive.Harvester.Application.Infrastructure.Models;
@@ -36,6 +35,19 @@ public class LiteDbJobReader(SignalQueueContext context)
             .Query()
             .Where(x => x.Status == status)
             .OrderByDescending(x => x.CreatedAt);
+
+        var count = query.Count();
+        var items = query.Skip(page * size).Limit(size).ToArray();
+
+        return new PagedResponse<JobDetails>(items, count);
+    }
+
+    public PagedResponse<JobDetails> GetJobs(int page, int size, params JobStatus[] statuses)
+    {
+        var query = Collection.Query();
+
+        query = query.Where(x => statuses.Contains(x.Status));
+        query = query.OrderByDescending(x => x.CreatedAt);
 
         var count = query.Count();
         var items = query.Skip(page * size).Limit(size).ToArray();

--- a/src/harvest/Fip.Strive.Harvester.Web/Components/Pages/QueuePage.razor
+++ b/src/harvest/Fip.Strive.Harvester.Web/Components/Pages/QueuePage.razor
@@ -5,7 +5,7 @@
 
 <MudGrid>
     <MudItem xs="3" md="6" sm="12">
-        <MudTable T="JobDetails" Context="job" Dense="true" Hover="true" ServerData="@OnUpcommingRequested">
+        <MudTable @ref="_activeTable" T="JobDetails" Context="job" OnRowClick="@OnRowClicked" Dense="true" Hover="true" ServerData="@OnActiveRequested">
             <ToolBarContent>
                 <MudText Typo="Typo.h2">Available Jobs</MudText>
             </ToolBarContent>
@@ -35,64 +35,9 @@
             </PagerContent>
         </MudTable>
     </MudItem>
+
     <MudItem xs="3" md="6" sm="12">
-        <MudTable T="JobDetails" Context="job" Dense="true" Hover="true" ServerData="@OnRunningRequested">
-            <ToolBarContent>
-                <MudText Typo="Typo.h2">Running Jobs</MudText>
-            </ToolBarContent>
-            <HeaderContent>
-                <MudTh>Signalled</MudTh>
-                <MudTh>Id</MudTh>
-                <MudTh>Type</MudTh>
-            </HeaderContent>
-            <ColGroup>
-                <col Style="width: 200px;"/>
-                <col />
-                <col Style="width: 300px;"/>
-            </ColGroup>
-            <RowTemplate>
-                <MudTd DataLabel="Signalled">@job.SignalledAt</MudTd>
-                <MudTd DataLabel="Id">@job.Id</MudTd>
-                <MudTd DataLabel="Type">@job.Type</MudTd>
-            </RowTemplate>
-            <NoRecordsContent>
-                <MudText>No matching records found</MudText>
-            </NoRecordsContent>
-            <PagerContent>
-                <MudTablePager/>
-            </PagerContent>
-        </MudTable>
-    </MudItem>
-    <MudItem xs="3" md="6" sm="12">
-        <MudTable T="JobDetails" Context="job" Dense="true" Hover="true" ServerData="@OnSucceededRequested">
-            <ToolBarContent>
-                <MudText Typo="Typo.h2">Succeeded Jobs</MudText>
-            </ToolBarContent>
-            <HeaderContent>
-                <MudTh>Signalled</MudTh>
-                <MudTh>Id</MudTh>
-                <MudTh>Type</MudTh>
-            </HeaderContent>
-            <ColGroup>
-                <col Style="width: 200px;"/>
-                <col />
-                <col Style="width: 300px;"/>
-            </ColGroup>
-            <RowTemplate>
-                <MudTd DataLabel="Signalled">@job.SignalledAt</MudTd>
-                <MudTd DataLabel="Id">@job.Id</MudTd>
-                <MudTd DataLabel="Type">@job.Type</MudTd>
-            </RowTemplate>
-            <NoRecordsContent>
-                <MudText>No matching records found</MudText>
-            </NoRecordsContent>
-            <PagerContent>
-                <MudTablePager/>
-            </PagerContent>
-        </MudTable>
-    </MudItem>
-    <MudItem xs="3" md="6" sm="12">
-        <MudTable T="JobDetails" Context="job" Dense="true" Hover="true" OnRowClick="@OnErrorRowClicked" ServerData="@OnFailedRequested">
+        <MudTable @ref="_doneTable" T="JobDetails" Context="job" Dense="true" Hover="true" OnRowClick="@OnRowClicked" ServerData="@OnDoneRequested">
             <ToolBarContent>
                 <MudText Typo="Typo.h2">Failed Jobs</MudText>
             </ToolBarContent>
@@ -100,16 +45,19 @@
                 <MudTh>Signalled</MudTh>
                 <MudTh>Id</MudTh>
                 <MudTh>Type</MudTh>
+                <MudTh>Status</MudTh>
             </HeaderContent>
             <ColGroup>
                 <col Style="width: 200px;"/>
                 <col />
-                <col Style="width: 300px;"/>
+                <col Style="width: 150px;"/>
+                <col Style="width: 150px;"/>
             </ColGroup>
             <RowTemplate>
                 <MudTd DataLabel="Signalled">@job.SignalledAt</MudTd>
                 <MudTd DataLabel="Id">@job.Id</MudTd>
                 <MudTd DataLabel="Type">@job.Type</MudTd>
+                <MudTd DataLabel="Status">@job.Status</MudTd>
             </RowTemplate>
             <NoRecordsContent>
                 <MudText>No matching records found</MudText>

--- a/src/harvest/Fip.Strive.Harvester.Web/Fip.Strive.Harvester.Web.csproj
+++ b/src/harvest/Fip.Strive.Harvester.Web/Fip.Strive.Harvester.Web.csproj
@@ -6,6 +6,7 @@
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Sinks.OpenTelemetry" />
+    <PackageReference Include="System.Reactive" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fip.Strive.Harvester.Application\Fip.Strive.Harvester.Application.csproj" />


### PR DESCRIPTION
Reworks the queue page to combine job tables, adds SignalR-based reactive updates using System.Reactive, and updates job repository interfaces to support multi-status queries. Changes DI lifetimes for ingestion services from singleton to scoped. Improves metrics handling in QueueRunner and updates project dependencies.