### PR TITLE
Add rebuild roadmap with per-step detail documents

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,36 @@
+# Roadmap — Strive Rebuild
+
+This roadmap turns the [wearable data platform spec](wearable-data-platform-spec.md) into an incremental build plan, reusing the existing codebase where it fits. Each step has a detail document and is only ticked off when its **done criterion** has been proven against real data.
+
+## Ground rules
+
+- **Incremental**: one step at a time; the next step starts only when the previous one works as expected.
+- **Observable**: every step ships UI to see what is happening and to validate the result.
+- **Self-healing**: all processing components (classifiers, readers, extractors, calculators, resolvers) are versioned; a version bump invalidates and replays only the affected data. Data is never mutated by hand.
+- **Provenance everywhere**: every stored value traces back to its source file (or input observations) and the component version that produced it.
+
+## Decisions that amend the spec
+
+The spec was written without knowledge of this repository or the homelab. These decisions supersede the corresponding spec sections:
+
+| Topic | Spec says | We decided |
+|---|---|---|
+| Storage | SQLite (metadata) + Parquet/DuckDB (series), embedded only | **Single PostgreSQL + TimescaleDB instance** for catalog, jobs, provenance, metrics and series. Raw blobs on the filesystem. The homelab provides Postgres and volume backups as a platform feature; a single store makes replace-by-provenance and the invalidation cascade one ACID transaction (resolves spec open question §14.6). |
+| Deployment | Single self-contained container | App container + Postgres/Timescale, orchestrated in the homelab. |
+| Parser shape | One parser per `(vendor, dataType)` file | **Two-tier extraction**: one *reader* per file format (parses the file once, streams decoded records) fanned out to many small *fact extractors* (one metric/series type each, individually versioned). |
+| Prototype migration (§14.7) | Open question | Classifiers and `FileProbe` are ported nearly as-is. Extractors are reshaped into readers + fact extractors, keeping their format knowledge. The distributed pipeline (RabbitMQ/Redis/worker CLIs) is **not** carried forward — everything runs in-process in the Blazor Server app, driven by a job table. |
+
+## Steps
+
+| # | Step | Detail | Status |
+|---|---|---|---|
+| 0 | Restructure repository, new solution, UI shell | [step-0-restructure.md](roadmap/step-0-restructure.md) | ☐ |
+| 1 | Zip upload & deduplication (L0) | [step-1-upload-dedup.md](roadmap/step-1-upload-dedup.md) | ☐ |
+| 2 | Job engine & status UI | [step-2-job-engine.md](roadmap/step-2-job-engine.md) | ☐ |
+| 3 | File classification | [step-3-classification.md](roadmap/step-3-classification.md) | ☐ |
+| 4 | Feature extraction (L1) | [step-4-extraction.md](roadmap/step-4-extraction.md) | ☐ |
+| 5 | Computed / derived values | [step-5-derived-values.md](roadmap/step-5-derived-values.md) | ☐ |
+| 6 | Merging / unification (L2) | [step-6-merging.md](roadmap/step-6-merging.md) | ☐ |
+| 7 | Reports (L3) | [step-7-reports.md](roadmap/step-7-reports.md) | ☐ |
+
+The pipeline steps map onto the spec's layers: step 1 builds L0 (raw), steps 3–5 build L1 (observations), step 6 builds L2 (canonical), step 7 builds L3 (reports). Step 2 is the cross-cutting orchestration every later step rides on.

--- a/docs/roadmap/step-0-restructure.md
+++ b/docs/roadmap/step-0-restructure.md
@@ -1,0 +1,36 @@
+# Step 0 — Restructure repository, new solution, UI shell
+
+## Goal
+
+Park the previous attempt as reference code, start a clean solution, and get an empty but running Blazor Server app with the basic layout in place.
+
+## Background
+
+The repository already contains two generations: the original ActivityAggregator (currently `src/legacy/`) and the distributed Harvester pipeline (current `src/`, `test/`). Both become read-only quarries. The distributed runtime (RabbitMQ/Redis/worker CLIs/Aspire) is deliberately not carried forward; the ingestion domain knowledge (classifiers, probe, extractor format logic) will be ported in later steps.
+
+## Tasks
+
+- [ ] Create `legacy/` with room for both generations:
+  - [ ] Move `src/legacy/TheFipster.ActivityAggregator.*` → `legacy/aggregator/`
+  - [ ] Move the current solution (`src/`, `test/`, `strive.sln`) → `legacy/harvester/`
+- [ ] Leave build output behind: no `bin/`/`obj/` trees make the move (the tree currently carries stale net9.0 artifacts).
+- [ ] Keep the seed test corpus at top level: `test/data/` (13 real Polar Flow exports, TheFipsterApp samples) stays out of `legacy/`, e.g. as `testdata/`.
+- [ ] Drop known dead weight instead of moving it:
+  - [ ] `test/queue/Fip.Strive.Queue.Application.UnitTests` (references deleted projects, not in the solution)
+  - [ ] Empty `src/queue/`, `src/indexing/`, stray `src/Fip.Strive.AppHost/` husks
+  - [ ] Unifier/Portal stub projects (empty shells, superseded by this roadmap)
+- [ ] Create the new solution `strive.sln` at the root:
+  - [ ] Keep central package management: `Directory.Packages.props`, `Directory.Build.props` (net10.0, nullable, implicit usings)
+  - [ ] New Blazor Server project with MudBlazor: top appbar with title, nav menu drawer
+  - [ ] Health endpoint, Serilog logging (port the minimal parts of `Core.Web` that earn their keep)
+- [ ] Fix CI: `.github/workflows/strive.yml` still pins .NET 9 and cannot build the solution — update to .NET 10, build the new solution.
+
+## Done criterion
+
+- The new solution builds and tests pass locally **and** in CI.
+- The app starts and shows the MudBlazor shell (appbar + nav menu).
+- Legacy code is fully out of the build but present under `legacy/` for reference.
+
+## Out of scope
+
+- Any pipeline functionality, database, or docker packaging.

--- a/docs/roadmap/step-1-upload-dedup.md
+++ b/docs/roadmap/step-1-upload-dedup.md
@@ -1,0 +1,36 @@
+# Step 1 — Zip upload & deduplication (L0)
+
+## Goal
+
+Build the content-addressed raw layer: upload vendor takeout ZIPs, unpack them, and catalog every contained file exactly once — no matter how many packages it appears in.
+
+## Design
+
+- **Content addressing by SHA-256** of the file bytes (replaces the previous xxHash3 — L0 identity must be collision-safe, and hashing cost is irrelevant at import frequency).
+- **CatalogEntry**: one row per unique blob (hash, size, first-seen). The same hash appearing under many paths in many packages stays one entry.
+- **ImportPackage**: one row per uploaded ZIP (archive hash, upload timestamp) plus the full `(pathInArchive → fileHash)` manifest, so every occurrence is recorded.
+- **Blob store**: raw bytes on the filesystem, sharded by hash prefix (`ab/cd/abcd…`). Blobs are immutable; identical content is written once.
+- **Upload**: drag-and-drop in the UI, streamed to disk (no in-memory buffering; raise Blazor upload limits). Duplicate archives (same archive hash) are rejected/reported, not re-imported.
+- **Storage**: catalog tables in PostgreSQL. First EF Core migrations of the new solution.
+- Unpacking may run synchronously in this step; it is retrofitted onto the job engine in step 2.
+
+## UI
+
+- Upload page with per-package progress.
+- Package list: uploaded archives, file counts, new-vs-known ratio.
+- Catalog browser: entries with size, hash, and the packages/paths each blob appeared in.
+
+## Tasks
+
+- [ ] Postgres wiring (EF Core, migrations) + `CatalogEntry`, `ImportPackage`, manifest tables
+- [ ] Streaming upload endpoint/page with progress
+- [ ] Unpack + SHA-256 + blob-store write with dedup-on-write
+- [ ] Package list and catalog browser pages
+
+## Done criterion
+
+Upload **two real takeout packages with overlapping content**. The shared files collapse to single catalog entries; the manifests record every path occurrence; re-uploading the same archive is detected as a duplicate and does no work. Verified visually in the catalog browser.
+
+## Out of scope
+
+- Classification, parsing, background jobs (step 2+).

--- a/docs/roadmap/step-2-job-engine.md
+++ b/docs/roadmap/step-2-job-engine.md
@@ -1,0 +1,36 @@
+# Step 2 — Job engine & status UI
+
+## Goal
+
+Build the single orchestration mechanism every later pipeline stage rides on: a persistent job table, an in-process background worker, and a live status UI. No stage ever grows its own ad-hoc progress/retry/status handling.
+
+## Design
+
+- **Job table** (Postgres): `(id, kind, targetKey, componentId, componentVersion, state, attempts, error, enqueued/started/finished timings)` with `state ∈ pending | running | succeeded | failed | stale`.
+- **Work units are keyed and versioned**: e.g. a later parse unit is `(catalogEntryId, extractorId)` and records the version that last succeeded. A component version bump marks its units `stale`, which re-queues them — this is the backbone of self-healing.
+- **Execution**: a hosted `BackgroundService` consuming a bounded `Channel<Job>`, parallelism tuned to the host (8 threads). Everything runs in-process in the Blazor Server app.
+- **Never tied to the SignalR circuit**: closing the browser tab must not kill a run. The UI is a *view* of the job table, not the owner of the work.
+- **Resumable**: on startup, `running` (interrupted) and `stale` jobs are re-enqueued.
+- Retrofit step 1's unpack/hash work as the first real job kind.
+
+## UI
+
+- Jobs page: live view of the job table — pending/running/failed counts, per-job state, durations, errors, retry action.
+- This page is the validation surface for every later step.
+
+## Tasks
+
+- [ ] Job table schema + repository
+- [ ] `BackgroundService` + bounded channel executor with configurable parallelism
+- [ ] Startup recovery (re-enqueue `running`/`stale`)
+- [ ] Staleness mechanic: component registry with versions; version change ⇒ mark units stale
+- [ ] Live jobs page (server push updates)
+- [ ] Retrofit unpacking as a job kind
+
+## Done criterion
+
+Start a large unpack run, **kill the app mid-run, restart** — the run resumes and completes with no duplicate or lost work. Closing the browser tab during a run has no effect on it. Job progress and errors are visible live in the UI.
+
+## Out of scope
+
+- Distributed execution, external queues, schedulers (Quartz/Hangfire) — revisit only if in-process ever proves insufficient.

--- a/docs/roadmap/step-3-classification.md
+++ b/docs/roadmap/step-3-classification.md
@@ -1,0 +1,35 @@
+# Step 3 — File classification
+
+## Goal
+
+Every catalog entry gets classified: which vendor, which data type, which reader/extractors could handle it. Unknowns are first-class citizens, permanently visible in the UI.
+
+## Design
+
+- **Port the legacy classifiers** (61 of them, covering Polar ProTrainer/Flow, RunGPS, GPSies, KML/GPX, Fitbit/Google, TheFipsterApp, Withings, Strava, Garmin, Google Timeline) and the `FileProbe` mechanism from `legacy/harvester/` — they worked well and move nearly as-is behind the new detector interface.
+- **Classification is separate from parsing** so it runs cheaply over everything and can be re-run independently.
+- A detector looks at cheap signals (path, extension, magic bytes, header peek) and proposes `(vendor, dataType, candidate readers)` with a confidence. Zero or more proposals per entry; ambiguous or unknown entries are flagged.
+- **Versioned**: classifiers carry a version; classification results are stored with `(classifierId, version)` provenance. Bumping a classifier re-queues only its work via the step 2 staleness mechanic.
+- Runs as jobs: one classification unit per catalog entry.
+
+## UI
+
+- **Coverage matrix** (successor of the legacy `/filehandler` page): sources × classifier/reader availability, so gaps are always apparent.
+- **Unknown/unclassified queue**: every entry without a confident classification, browsable — this is where deferred formats (e.g. Withings EKG) surface and wait.
+- Catalog browser gains classification filters.
+
+## Tasks
+
+- [ ] Detector interface + DI discovery + version registry
+- [ ] Port `FileProbe` and the 61 classifiers; keep their behavior (verified against the seed corpus in `testdata/`)
+- [ ] Classification job kind + result storage with provenance
+- [ ] Coverage matrix page, unknown queue page, catalog filters
+- [ ] Port/extend the legacy classify round-trip tests
+
+## Done criterion
+
+Classify the **full real corpus (~15 GB uncompressed)** via the job engine. Every entry is either confidently classified or visible in the unknown queue; results for the seed corpus match the legacy prototype's classifications; re-running after a classifier version bump reclassifies only that classifier's entries.
+
+## Out of scope
+
+- Extraction of any data (step 4). Classification only tags.

--- a/docs/roadmap/step-4-extraction.md
+++ b/docs/roadmap/step-4-extraction.md
@@ -1,0 +1,57 @@
+# Step 4 — Feature extraction (L1)
+
+## Goal
+
+Turn classified files into typed, unit-normalized **observations** (metrics and series) with full provenance, stored in PostgreSQL/TimescaleDB. This step also carries the roadmap's biggest technical risk gate: proving the series schema at RR-interval volume.
+
+## Design
+
+### Two-tier extraction
+
+- **Reader** — one per file format (roughly one per legacy extractor). Opens the file **once** and streams decoded records (trackpoints, sleep phases, JSON nodes) as `IAsyncEnumerable`; never loads whole files. Owns the ugly format knowledge, ported from the legacy extractors.
+- **Fact extractor** — many, tiny; each subscribes to a reader's record stream and projects out **one metric or series type** with its provenance locator. Individually versioned.
+- The pipeline runs the reader once per file and fans records out to every registered — or every *stale* — fact extractor in a single pass. Per-fact code and versioning without I/O amplification.
+- Granularity rule: a fact is one metric/series **type**, not one column. Latitude+longitude is one position fact; values only meaningful together are one fact.
+
+### Data model
+
+- **Buckets**: `Day` (calendar date + timezone) and `Session` (sport, start, end), both hanging off a single explicit `Subject`.
+- **Metric**: `(bucketRef, metricTypeId, value, unit, provenanceRef)` — scalar facts.
+- **Series**: header `(bucketRef, seriesTypeId, kind ∈ Interval|Period, unit, provenanceRef)` + points. Interval points as `(timestamp|offset, value)`; RR intervals stay irregular `(timestamp, rrMillis)`. Period points as `(from, to, label|value)`.
+- **Controlled vocabulary**: curated vendor-independent `MetricType`/`SeriesType` (seeded from the legacy `Parameters` enum, 43 members) with a canonical unit per type; vendor fields and units are normalized during extraction (semicircles→degrees, cm/m, kcal/kJ, …).
+- **Provenance**: `(fileHash, readerId, extractorId, extractorVersion, runId, locator)` on every observation. Values are typed, not strings — the legacy stringly-typed `FileExtraction` shape is not carried forward.
+
+### Storage
+
+- Metrics and bucket/vocabulary/provenance tables: regular Postgres tables.
+- Series points: **TimescaleDB hypertables** with native compression, chunked by time.
+- Replace-by-provenance: re-running an extractor deletes and re-inserts its observations in one transaction.
+
+## Risk gate: RR volume validation
+
+Years of RR data ≈ 50–100k rows/day ⇒ tens to 100+ million rows. As soon as extraction can emit series, feed it the biggest RR/PPI export and measure: insert throughput, compressed chunk size on disk, and representative aggregate queries (`time_bucket` over months). If the schema needs rework, it must happen **before** steps 5–7 build on it.
+
+## UI
+
+- Extraction status per source type (extends the coverage matrix: classified vs extracted).
+- Bucket browser: days/sessions with their metrics and series, chart preview per series.
+- **Provenance drill-down**: from any displayed value to file, reader/extractor, version, locator.
+
+## Tasks
+
+- [ ] Vocabulary, bucket, metric, series, provenance schema + Timescale hypertables
+- [ ] Reader + fact-extractor interfaces, DI discovery, version registry, single-pass fan-out
+- [ ] Port legacy extractor format logic into readers; reshape outputs into fact extractors
+- [ ] Extraction job kind wired to staleness (per `(catalogEntryId, extractorId)`)
+- [ ] RR volume validation run + recorded results
+- [ ] Bucket browser + provenance drill-down pages
+- [ ] Port/extend the extract round-trip tests against `testdata/`
+
+## Done criterion
+
+The seed corpus extracts to typed observations verifiable in the bucket browser with working provenance drill-down. The **RR volume gate passes**: full-history RR ingest completes, storage lands in expected bounds after compression, and month-scale aggregates return in seconds. An extractor version bump replays only that fact's observations.
+
+## Out of scope
+
+- Values computed *from* observations (step 5), any cross-source merging (step 6).
+- New formats without legacy extractors (Garmin FIT, Withings EKG, …) — they remain classified-but-deferred and visible in the unknown/deferred queue.

--- a/docs/roadmap/step-5-derived-values.md
+++ b/docs/roadmap/step-5-derived-values.md
@@ -1,0 +1,36 @@
+# Step 5 — Computed / derived values
+
+## Goal
+
+Compute per-source derived observations from extracted ones — and in doing so, establish the lineage model that step 6's merge layer will reuse.
+
+## Design
+
+- **Calculators**: versioned, DI-discovered components, structurally like fact extractors, but consuming observations instead of file records. Each declares its input types and produces one derived metric/series type.
+- Examples: HRV metrics from RR series, distance by cumulative trapezoidal integration of speed over time, altitude gain/loss from an altitude series, session summaries (max/avg HR) where the source didn't provide them.
+- **Per-source only**: a calculator derives within one source's data. Anything combining sources is merging and belongs to step 6.
+- **Lineage instead of a file locator**: a derived observation's provenance is *(input observation ids, calculatorId, calculatorVersion, runId)*. This is the first provenance that points at observations rather than bytes — deliberately the same shape L2 canonical values need. Step 5 is the dress rehearsal for step 6's lineage model.
+- **Invalidation cascade begins here**: when an upstream extractor replays (step 4 staleness), derived values whose lineage references the replaced observations become stale and recompute. First real test of lineage-driven, precise invalidation.
+- Derived observations are stored as L1 observations (same tables), flagged as derived.
+
+## UI
+
+- Calculators list with versions, inputs/outputs, run status.
+- Bucket browser shows derived values alongside extracted ones; provenance drill-down follows lineage to the input observations and onward to the source file.
+
+## Tasks
+
+- [ ] Calculator interface + registry + job kind (unit: `(bucketId | seriesId, calculatorId)`)
+- [ ] Lineage-capable provenance (observation-ref inputs)
+- [ ] Staleness cascade: extractor replay ⇒ dependent calculator units stale
+- [ ] First calculators: distance-from-speed integration, basic HRV (e.g. RMSSD daily), session HR summary
+- [ ] UI integration + drill-down through lineage
+- [ ] Unit tests with known input/output fixtures
+
+## Done criterion
+
+Bump a calculator version: **only** that calculator's derived values are recomputed. Replay an upstream extractor: exactly the derived values depending on its observations go stale and recompute — nothing else. Both verified via the jobs page and drill-down.
+
+## Out of scope
+
+- Cross-source computation, conflict resolution, fusion (step 6).

--- a/docs/roadmap/step-6-merging.md
+++ b/docs/roadmap/step-6-merging.md
@@ -1,0 +1,42 @@
+# Step 6 — Merging / unification (L2)
+
+## Goal
+
+Compute the canonical layer: merged, deduplicated, conflict-resolved, sensor-fused data — derived from L1 by explicit, versioned **resolvers**, never hand-edited. This is the hard part of the whole platform (spec §7).
+
+## Design
+
+- **Resolvers**: pluggable, DI-discovered, versioned components (same skeleton as calculators, operating L1→L2). Each declares what it consumes (metric/series types, bucket type, applicability predicate) and emits canonical observations **with lineage** to the L1 observations and its own `(resolverId, version)`.
+- **Session grouping is the prerequisite**: cluster session-scoped observations by overlapping time windows (+ sport hints) into candidate **SessionGroups**. Grouping must be reviewable and overridable in the UI — clock drift and near-simultaneous activities make it occasionally ambiguous.
+- Canonical values live in the same Postgres/Timescale instance, so replace-by-lineage and cascade invalidation stay single-transaction.
+
+### Fusion taxonomy (build in this order)
+
+1. **Type A — temporal handover**: disjoint source ranges stitched into one continuous series (Polar → Fitbit → Polar eras). Dedup boundary overlaps; prefer a configured source at the seams.
+2. **Type B — competing overlap**: both sources claim the same fact (Garmin vs Polar sleep). Keep both in L1; L2 applies **source-priority selection per metric type**, and reports may override the selection. Never collapse destructively.
+3. **Type C — session fusion by time sync**: complementary series (HR from one device, GPS from another) aligned on a common start with configurable offset correction.
+4. **Type D — session fusion by distance registration**: GPS track without trustworthy timing joined to an HR/speed log by aligning cumulative distances — integrate speed→distance, cumulative haversine over the track, reconcile the two distance axes (linear scale first; monotonic warp/DTW only if real data demands it), interpolate positions per time sample.
+
+- **Source-priority configuration**: per-metric-type priorities, versioned alongside resolvers; time-ranged rules if device eras require it.
+
+## UI
+
+- SessionGroup review: candidate groupings, member files, override (merge/split) controls.
+- Conflict inspector: competing-source situations per metric type, current priority, per-value winner with lineage.
+- Resolver list with versions and run status.
+
+## Tasks
+
+- [ ] SessionGroup builder + review/override UI
+- [ ] Resolver interface + registry + job kind (unit: `(sessionGroupId | dayId, resolverId)`)
+- [ ] Canonical storage with lineage; staleness cascade from L1 replays
+- [ ] Type A resolver → Type B + source-priority config → Type C → Type D, each validated on the real cases that motivated it
+- [ ] Tests per resolver with fixture data (esp. Type D distance registration)
+
+## Done criterion
+
+Each type proves out on its real motivating data: (A) one continuous canonical series across the Polar/Fitbit/Polar eras with clean seams; (B) Garmin-vs-Polar sleep nights where both claims survive in L1 and the priority pick is visible with lineage; (C) an old-watch HR + smartphone GPS run fused on a common clock; (D) an HR/speed log + timing-less GPS track fused by distance registration into one session. A resolver version bump recomputes only its L2 output.
+
+## Out of scope
+
+- Reports/aggregates over canonical data (step 7).

--- a/docs/roadmap/step-7-reports.md
+++ b/docs/roadmap/step-7-reports.md
@@ -1,0 +1,36 @@
+# Step 7 — Reports (L3)
+
+## Goal
+
+Pre-built reports and dashboards over canonical data, materialized by background jobs — and the end-to-end proof that the self-healing cascade works from a code fix all the way to a corrected chart.
+
+## Design
+
+- **Reports are jobs**: background jobs compute aggregates over L2 and materialize them as L3. No live/interactive analysis path; dashboards only read L3.
+- **Reports are versioned and lineage-aware** like every other component: each materialized report records the L2 lineage and report-code version it was built from, so it is reproducible and precisely invalidated when upstream data heals.
+- **Source-parameterized reports** (Type B follow-through): the same report can be built against different source selections (e.g. Garmin-sleep vs Polar-sleep) and is labeled with the selection it used; comparison reports show sources side by side.
+- Dashboards: daily metrics, training sessions, HRV/RR-derived trends, source comparisons. Charts follow the project's dataviz conventions.
+- Provenance drill-down completes: from a number on a dashboard → L3 report → L2 canonical value → L1 observation(s) → file + locator.
+
+## UI
+
+- Dashboard pages reading L3.
+- Report registry: available reports, versions, parameterization, last build, staleness.
+- Drill-down from any chart value to its full lineage.
+
+## Tasks
+
+- [ ] L3 storage + report job kind (unit: `(reportId, parameterization)`)
+- [ ] Invalidation cascade L2→L3 via lineage
+- [ ] First reports: weekly/monthly daily-metric trends, training load overview, HRV trend, one source-comparison report (sleep: Garmin vs Polar)
+- [ ] Dashboard pages + drill-down
+- [ ] Report reproducibility test (same inputs + version ⇒ identical output)
+
+## Done criterion
+
+**The full self-healing loop closes**: fix a bug in one extractor, bump its version, and watch the cascade — only the affected observations replay (L1), only the dependent derived/canonical values recompute (L1/L2), only the reports built on them rebuild (L3) — with the corrected number visible on the dashboard and every other report untouched. No manual cleanup at any point.
+
+## Out of scope
+
+- New parsers/formats (they slot into steps 3–4 whenever written, e.g. Garmin FIT, Withings EKG).
+- Multi-user, auth, real-time analysis (spec non-goals).


### PR DESCRIPTION
## Summary

Turns the [wearable data platform spec](https://github.com/thefipster/strive/blob/main/docs/wearable-data-platform-spec.md) into an incremental build plan based on our comparison of the spec against the existing codebase.

- **[docs/roadmap.md](../blob/docs/roadmap/docs/roadmap.md)** — brief overview: ground rules, decisions that amend the spec, and the step checklist.
- **docs/roadmap/step-*.md** — one detail document per step with design notes, task checklists, and a done criterion proven against real data, so steps can be ticked off one by one.

## Key decisions captured

- Single **PostgreSQL + TimescaleDB** store (catalog, jobs, provenance, metrics, series) instead of the spec''s SQLite + Parquet/DuckDB split; raw blobs on the filesystem. Resolves spec open question §14.6 — the invalidation cascade becomes one ACID transaction. Backups are a homelab platform feature.
- The distributed pipeline (RabbitMQ/Redis/worker CLIs) is **not** carried forward; everything runs in-process, driven by a persistent job table (step 2).
- Legacy classifiers and `FileProbe` are ported nearly as-is; extractors are reshaped into a **two-tier reader / fact-extractor** design (one file parse, many small versioned per-fact extractors).
- Step 4 carries the **RR-interval volume risk gate**; step 5 (derived values) establishes the lineage model step 6 (merging) reuses; step 7 closes the end-to-end self-healing loop.

## Steps

0. Restructure repository, new solution, MudBlazor UI shell
1. Zip upload & deduplication (L0)
2. Job engine & status UI
3. File classification
4. Feature extraction (L1) + RR volume gate
5. Computed / derived values
6. Merging / unification (L2)
7. Reports (L3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)